### PR TITLE
Updated photoprism PKGBUILD configuration for using git repository

### DIFF
--- a/photoprism/.SRCINFO
+++ b/photoprism/.SRCINFO
@@ -13,7 +13,7 @@ pkgbase = photoprism
 	provides = photoprism
 	conflicts = photoprism
 	backup = etc/photoprism/options.yml
-	source = https://github.com/photoprism/photoprism/archive/220107-f5b7ef83.tar.gz
+	source = git+https://github.com/photoprism/photoprism.git#tag=220107-f5b7ef83
 	source = https://dl.photoprism.org/tensorflow/nasnet.zip
 	source = https://dl.photoprism.org/tensorflow/facenet.zip
 	source = https://dl.photoprism.org/tensorflow/nsfw.zip
@@ -21,7 +21,7 @@ pkgbase = photoprism
 	source = photoprism.sysusers
 	source = options.yml
 	source = photoprism.tmpfiles
-	sha256sums = d92064f73ad98c4038e72d4c6b9999473d0c68da4e4ed58a53dfcd553b433b1a
+	sha256sums = SKIP
 	sha256sums = a0e1ad8d5a5a0ff9efc4b3ed89898bf008563ee36cacd0c804a384f8fc661588
 	sha256sums = bf9ae0945d2ac53ac3db27082162d2b9dda5ba2c564c0e4c4f539f31f8b670af
 	sha256sums = eb5e5d22e37961c3192a4757efff883f77bc989c0efceabb1395e0959d966f14

--- a/photoprism/PKGBUILD
+++ b/photoprism/PKGBUILD
@@ -23,8 +23,15 @@ backup=("etc/photoprism/options.yml")
 options=()
 install=
 changelog=
-source=("https://github.com/photoprism/photoprism/archive/$pkgver-$commit.tar.gz" "https://dl.photoprism.org/tensorflow/nasnet.zip" "https://dl.photoprism.org/tensorflow/facenet.zip" "https://dl.photoprism.org/tensorflow/nsfw.zip" "photoprism.service" "photoprism.sysusers" "options.yml" "photoprism.tmpfiles")
-sha256sums=('d92064f73ad98c4038e72d4c6b9999473d0c68da4e4ed58a53dfcd553b433b1a'
+source=("git+https://github.com/photoprism/photoprism.git#tag=${pkgver}-${commit}" # "git+https://github.com/photoprism/photoprism.git#commit=$commit"
+        "https://dl.photoprism.org/tensorflow/nasnet.zip"
+        "https://dl.photoprism.org/tensorflow/facenet.zip"
+        "https://dl.photoprism.org/tensorflow/nsfw.zip"
+        "photoprism.service"
+        "photoprism.sysusers"
+        "options.yml"
+        "photoprism.tmpfiles")
+sha256sums=('SKIP'
             'a0e1ad8d5a5a0ff9efc4b3ed89898bf008563ee36cacd0c804a384f8fc661588'
             'bf9ae0945d2ac53ac3db27082162d2b9dda5ba2c564c0e4c4f539f31f8b670af'
             'eb5e5d22e37961c3192a4757efff883f77bc989c0efceabb1395e0959d966f14'
@@ -36,7 +43,7 @@ noextract=()
 validpgpkeys=()
 
 build() {
-	cd "$pkgname"-"$pkgver"-"$commit"
+	cd "$pkgname"
 	scripts/build.sh prod ./photoprism
 
 	cd "frontend";
@@ -45,7 +52,7 @@ build() {
 }
 
 check() {
-	"$pkgname"-"$pkgver"-"$commit/photoprism" --version
+	"$pkgname/photoprism" --version
 }
 
 package() {
@@ -60,7 +67,7 @@ package() {
 
 	cp -r "${srcdir}/nasnet" "${srcdir}/facenet" "${srcdir}/nsfw" "$pkgdir/var/lib/photoprism/assets/"
 
-	cd "$pkgname"-"$pkgver"-"$commit"
+	cd "$pkgname"
 
 	install -Dm 0755 ./photoprism "$pkgdir/usr/bin/photoprism"
 	cp -r assets/locales assets/profiles assets/static assets/templates "$pkgdir/var/lib/photoprism/assets/"


### PR DESCRIPTION
Updated photoprism PKGBUILD configuration for using files from github repository.
Also, this change fixes the problem with PHOTOPRISM_VERSION in scripts/build.sh