### PR TITLE
Add photoprism optdepends

### DIFF
--- a/photoprism/PKGBUILD
+++ b/photoprism/PKGBUILD
@@ -15,7 +15,11 @@ groups=()
 depends=(tensorflow115 icu)
 makedepends=(go nodejs npm git)
 checkdepends=()
-optdepends=()
+optdepends=("darktable: for RAW to JPEG conversion"
+	    "rawtherapee: for RAW to JPEG conversion"
+	    "libheif: for HEIC/HEIF image conversion"
+	    "ffmpeg: for video transcoding and thumbnail extraction"
+	    "exiftool: for extracting metadata")
 provides=("photoprism")
 conflicts=("photoprism")
 replaces=()


### PR DESCRIPTION
Found these via searching for `_BIN` in https://docs.photoprism.app/getting-started/config-options/

afaict, they are all optional

Thanks for this package!

Closes #5.
